### PR TITLE
v18 cleanup: version alignment, idempotent install, review fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "roam-depot-todo-progress-bar",
-  "version": "11.0.0",
+  "version": "18.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "roam-depot-todo-progress-bar",
-      "version": "11.0.0",
+      "version": "18.0.0",
       "license": "MIT",
       "devDependencies": {
-        "css-loader": "^6.7.3",
         "text-loader": "^0.0.1",
         "webpack": "^5.73.0",
         "webpack-cli": "^4.10.0"
@@ -459,44 +458,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-loader": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
-      "integrity": "sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.19",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">= 12.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -668,18 +629,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -803,18 +752,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -840,24 +777,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/neo-async": {
@@ -949,112 +868,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/postcss": {
-      "version": "8.4.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.22.tgz",
-      "integrity": "sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
-      "dev": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
-      "dev": true,
-      "dependencies": {
-        "icss-utils": "^5.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
-      "dev": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.2.0",
@@ -1162,21 +975,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -1223,15 +1021,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1375,12 +1164,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
     },
     "node_modules/watchpack": {
       "version": "2.4.0",
@@ -1539,12 +1322,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-      "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     }
   },
@@ -1919,28 +1696,6 @@
         "which": "^2.0.1"
       }
     },
-    "css-loader": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.3.tgz",
-      "integrity": "sha512-qhOH1KlBMnZP8FzRO6YCH9UHXQhVMcEGLyNdb7Hv2cpcmJbW0YrddO+tG1ab5nT41KpHIYGsbeHqxB9xPu1pKQ==",
-      "dev": true,
-      "requires": {
-        "icss-utils": "^5.1.0",
-        "postcss": "^8.4.19",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "postcss-value-parser": "^4.2.0",
-        "semver": "^7.3.8"
-      }
-    },
-    "cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true
-    },
     "electron-to-chromium": {
       "version": "1.4.284",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
@@ -2075,13 +1830,6 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
-    "icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
-    },
     "import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -2172,15 +1920,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2201,12 +1940,6 @@
       "requires": {
         "mime-db": "1.52.0"
       }
-    },
-    "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-      "dev": true
     },
     "neo-async": {
       "version": "2.6.2",
@@ -2277,69 +2010,6 @@
         "find-up": "^4.0.0"
       }
     },
-    "postcss": {
-      "version": "8.4.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.22.tgz",
-      "integrity": "sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==",
-      "dev": true,
-      "requires": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      }
-    },
-    "postcss-modules-extract-imports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
-    },
-    "postcss-modules-local-by-default": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
-      "dev": true,
-      "requires": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^6.0.2",
-        "postcss-value-parser": "^4.1.0"
-      }
-    },
-    "postcss-modules-scope": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
-      "dev": true,
-      "requires": {
-        "postcss-selector-parser": "^6.0.4"
-      }
-    },
-    "postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
-      "dev": true,
-      "requires": {
-        "icss-utils": "^5.0.0"
-      }
-    },
-    "postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
-      "dev": true,
-      "requires": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      }
-    },
-    "postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
-    },
     "punycode": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
@@ -2407,15 +2077,6 @@
         "ajv-keywords": "^3.5.2"
       }
     },
-    "semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
     "serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -2453,12 +2114,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
-    "source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
     "source-map-support": {
@@ -2541,12 +2196,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
     },
     "watchpack": {
       "version": "2.4.0",
@@ -2647,12 +2296,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roam-depot-todo-progress-bar",
-  "version": "17.0.0",
+  "version": "18.0.0",
   "description": "Roam Research Plugin",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,6 @@
   "license": "MIT",
   "author": "Matt Vogel",
   "devDependencies": {
-    "css-loader": "^6.7.3",
     "text-loader": "^0.0.1",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0"

--- a/src/component.cljs
+++ b/src/component.cljs
@@ -1,10 +1,10 @@
-(ns progress-bar-v17
+(ns progress-bar-v18
   (:require
    [reagent.core :as r]
-   [datascript.core :as d]
    [roam.datascript.reactive :as dr]
    [roam.block :as block]
-   [blueprintjs.core :as bp-core]))
+   [blueprintjs.core :as bp-core]
+   [clojure.string :as str]))
 
 ;; Circle configuration
 (def base-size 11)
@@ -12,11 +12,8 @@
 (def viewbox-size (* 2 base-size))
 (def center-point base-size)
 
-(defn debug
-  "Debug function that converts ClojureScript data to JavaScript objects for better console display"
-  [label data]
-  (js/console.log label (clj->js data))
-  data)
+(defn truthy? [value]
+  (or (= value true) (= value "true")))
 
 (defn calculate-coordinates [percentage]
   (let [angle (* (/ percentage 100) (* 2 js/Math.PI))
@@ -35,86 +32,74 @@
       (str "M " center-point "," start-y " A " radius "," radius " 0 " large-arc ",1 "
            x "," y " L " center-point "," center-point " Z"))))
 
-;; Helper functions - OPTIMIZED WITH PULL QUERIES
-(defn flatten-block [acc block]
-  (reduce flatten-block
-          (conj acc (dissoc block :block/children))
-          (:block/children block)))
-
-;; Using pull for page title lookup
-(defn id-title [id]
-  (:node/title @(dr/pull '[:node/title] id)))
-
-(defn info-from-id [id]
-  (or (:node/title @(dr/pull '[:node/title] id))
-      (map id-title
-           (map :db/id
-                (:block/refs @(dr/pull '[:block/refs] id))))))
-
-(defn count-occurrences [s slist]
-  (->> slist
-       flatten
-       (filter #{s})
-       count))
-
 (defn is-block-ref?
-  "Returns true if block-string is a pure block reference ((uid)).
-   Roam UIDs are exactly 9 characters: [a-zA-Z0-9_-]{9}"
+  "Returns true if block-string is a pure block reference ((uid))."
   [block-string]
   (when block-string
-    (boolean (re-matches #"^\s*\(\([a-zA-Z0-9_-]{9}\)\)\s*$" block-string))))
+    (boolean (re-matches #"^\s*\(\([a-zA-Z0-9_-]+\)\)\s*$" block-string))))
 
-;; Legacy function kept for backward compatibility
-(defn find-child-refs [block-uid]
-  (flatten-block []
-                 @(dr/pull '[:block/refs :block/string {:block/children ...}]
-                          [:block/uid block-uid])))
+(defn count-status-from-ref [ref]
+  (let [title (:node/title ref)]
+    (cond
+      (= title "TODO") [1 0]
+      (= title "DONE") [0 1]
+      :else (reduce (fn [[todo done] nested-ref]
+                      (let [nested-title (:node/title nested-ref)]
+                        (cond
+                          (= nested-title "TODO") [(inc todo) done]
+                          (= nested-title "DONE") [todo (inc done)]
+                          :else [todo done])))
+                    [0 0]
+                    (:block/refs ref)))))
 
-;; Main approach to find all references in child blocks
-;; so the issue here was that the top level embeded block is already being included i
-;; in the todo count. to 'really' count embeds we'd have to get the children of the embed
+(defn count-status-from-block [block]
+  (reduce (fn [[todo done] ref]
+            (let [[todo+ done+] (count-status-from-ref ref)]
+              [(+ todo todo+) (+ done done+)]))
+          [0 0]
+          (:block/refs block)))
 
-(defn recurse-search
-  "Search for TODO/DONE refs in child blocks.
-   When exclude-blockrefs? is true, blocks that are just block references ((uid)) are excluded."
-  ([block-uid] (recurse-search block-uid false))
-  ([block-uid exclude-blockrefs?]
-   (let [blocks (find-child-refs block-uid)
-         filtered-blocks (if exclude-blockrefs?
-                           (remove #(is-block-ref? (:block/string %)) blocks)
-                           blocks)]
-     (->> filtered-blocks
-          (keep :block/refs) ;; pulls out just the refs for each block. this would include any pages
-          (flatten)
-          (map :db/id) ;; manipulate the data to get just the ids of the pages referenced in those blocks
-          (map info-from-id) ;; gets a page name from the db id
-          (flatten)))))
+(defn progress-counts [block-uid exclude-blockrefs?]
+  (let [root @(dr/pull '[:block/string
+                         {:block/refs [:node/title {:block/refs [:node/title]}]}
+                         {:block/children ...}]
+                       [:block/uid block-uid])]
+    (loop [stack (if root [root] [])
+           todo 0
+           done 0]
+      (if (empty? stack)
+        {:todo todo :done done}
+        (let [node (peek stack)
+              next-stack (into (pop stack) (:block/children node))
+              include-block? (or (not exclude-blockrefs?)
+                                 (not (is-block-ref? (:block/string node))))
+              [todo+ done+] (if include-block?
+                              (count-status-from-block node)
+                              [0 0])]
+          (recur next-stack (+ todo todo+) (+ done done+)))))))
 
-;; BlueprintJS component adaptations
 (def bp-button (r/adapt-react-class bp-core/Button))
 (def bp-popover (r/adapt-react-class bp-core/Popover))
-(def bp-menu (r/adapt-react-class bp-core/Menu))
-(def bp-menu-item (r/adapt-react-class bp-core/MenuItem))
 (def bp-select (r/adapt-react-class bp-core/HTMLSelect))
 (def bp-input (r/adapt-react-class bp-core/InputGroup))
 (def bp-switch (r/adapt-react-class bp-core/Switch))
 
-;; Component configuration management
 (defn get-component-code-uid [block-string]
   (when block-string
     (let [pattern #"\{\{(?:\[\[)?roam/render(?:\]\])?: *\(\(([^)]+)\)\).*\}\}"
           matches (re-find pattern block-string)]
       (second matches))))
 
+;; Render-string positional args: style, status-text, show-percent, exclude-blockrefs
 (defn format-render-string [current-string style status-text show-percent exclude-blockrefs]
   (if-let [code-block-uid (get-component-code-uid current-string)]
     (let [pattern #"\{\{(?:\[\[)?roam/render(?:\]\])?: *\(\([^)]+\)\).*?\}\}"
           replacement (str "{{roam/render: ((" code-block-uid ")) \""
-                         style "\" \""
-                         status-text "\" \""
-                         show-percent "\" \""
-                         exclude-blockrefs "\"}}")]
-      (clojure.string/replace current-string pattern replacement))
+                           style "\" \""
+                           status-text "\" \""
+                           show-percent "\" \""
+                           exclude-blockrefs "\"}}")]
+      (str/replace current-string pattern replacement))
     current-string))
 
 (defn update-block-string [block-uid style status-text show-percent exclude-blockrefs]
@@ -123,10 +108,9 @@
         new-string (format-render-string current-string style status-text show-percent exclude-blockrefs)]
     (when (not= current-string new-string)
       (block/update
-        {:block {:uid block-uid
-                 :string new-string}}))))
+       {:block {:uid block-uid
+                :string new-string}}))))
 
-;; Settings menu
 (defn settings-menu [block-uid current-style current-status-text current-show-percent current-exclude-blockrefs on-close]
   (let [*style (r/atom current-style)
         *status-text (r/atom current-status-text)
@@ -153,13 +137,13 @@
 
        [:div.setting-group.dont-focus-block {:style {:margin-bottom "15px"}}
         [:label.bp3-label.dont-focus-block "Show Percentage"]
-        [bp-switch {:checked (or (= @*show-percent "true") (= @*show-percent true))
+        [bp-switch {:checked (truthy? @*show-percent)
                     :class "dont-focus-block"
                     :onChange #(reset! *show-percent (str (.. % -target -checked)))}]]
 
        [:div.setting-group.dont-focus-block {:style {:margin-bottom "15px"}}
         [:label.bp3-label.dont-focus-block "Exclude Reference-Only Blocks"]
-        [bp-switch {:checked (or (= @*exclude-blockrefs "true") (= @*exclude-blockrefs true))
+        [bp-switch {:checked (truthy? @*exclude-blockrefs)
                     :class "dont-focus-block"
                     :onChange #(reset! *exclude-blockrefs (str (.. % -target -checked)))}]]
 
@@ -169,56 +153,55 @@
                     :minimal true}
          "Cancel"]
         [bp-button {:intent "primary"
-            :class "dont-focus-block"
-            :onClick (fn [e]
-                       (.stopPropagation e)
-                       (.preventDefault e)
-                       (update-block-string block-uid @*style @*status-text @*show-percent @*exclude-blockrefs)
-                       (on-close))}
-          "Apply"]
-         ]])))
+                    :class "dont-focus-block"
+                    :onClick (fn [e]
+                               (.stopPropagation e)
+                               (.preventDefault e)
+                               (update-block-string block-uid @*style @*status-text @*show-percent @*exclude-blockrefs)
+                               (on-close))}
+         "Apply"]]])))
 
-(defn horizontal-progress-bar [block-uid done total status-text show-percent on-settings-click]
+(defn horizontal-progress-bar [done total status-text show-percent on-settings-click]
   (r/with-let [*hovered? (r/atom false)]
     [:span {:style {:display "inline-flex"
-                   :align-items "center"
-                   :gap "8px"
-                   :vertical-align "middle"}
-           :on-mouse-enter #(reset! *hovered? true)
-           :on-mouse-leave #(reset! *hovered? false)}
+                    :align-items "center"
+                    :gap "8px"
+                    :vertical-align "middle"}
+            :on-mouse-enter #(reset! *hovered? true)
+            :on-mouse-leave #(reset! *hovered? false)}
      [:span {:style {:display "inline-block"
-                    :width "150px"}} 
+                     :width "150px"}}
       [:progress {:id "file"
                   :name "percent-done"
                   :value done
                   :max total
                   :style {:width "100%"}}]]
      [:span {:style {:white-space "nowrap"
-                    :display "inline-flex"
-                    :align-items "center"}}
+                     :display "inline-flex"
+                     :align-items "center"}}
       [:span (str done "/" total " " status-text
-                (when (or (= show-percent "true") (= show-percent true))
-                  (str " - " (if (zero? total) 0 (int (* (/ done total) 100))) "%")))]
+                  (when (truthy? show-percent)
+                    (str " - " (if (zero? total) 0 (int (* (/ done total) 100))) "%")))]
       [:span {:style {:max-width (if @*hovered? "30px" "0px")
-                     :overflow "hidden" 
-                     :margin-left (if @*hovered? "8px" "0")
-                     :transition "all 0.3s ease-in-out"
-                     :opacity (if @*hovered? "1" "0")
-                     :display "inline-block"}}
+                      :overflow "hidden"
+                      :margin-left (if @*hovered? "8px" "0")
+                      :transition "all 0.3s ease-in-out"
+                      :opacity (if @*hovered? "1" "0")
+                      :display "inline-block"}}
        [bp-button
         {:icon "cog"
          :class "dont-focus-block"
          :minimal true
          :small true
-         :onClick (fn [e] 
+         :onClick (fn [e]
                     (.stopPropagation e)
                     (on-settings-click))}]]]]))
 
-(defn circle-progress-bar [block-uid done total status-text show-percent on-settings-click]
+(defn circle-progress-bar [done total status-text show-percent on-settings-click]
   (r/with-let [*hovered? (r/atom false)]
     (let [percentage (if (zero? total)
-                      0
-                      (* (/ done total) 100))]
+                       0
+                       (* (/ done total) 100))]
       [:span.inline-flex.items-center.gap-2
        {:style {:vertical-align "middle"}
         :on-mouse-enter #(reset! *hovered? true)
@@ -240,48 +223,55 @@
            :fill "var(--circle-fill, #0d8050)"
            :stroke "none"}]]]
        [:span {:style {:display "inline-flex"
-                      :align-items "center"}}
+                       :align-items "center"}}
         [:span.text-base
          (str done "/" total " " status-text
-              (when (or (= show-percent "true") (= show-percent true))
+              (when (truthy? show-percent)
                 (str " - " (int percentage) "%")))]
         [:span {:style {:max-width (if @*hovered? "30px" "0px")
-                       :overflow "hidden" 
-                       :margin-left (if @*hovered? "8px" "0")
-                       :transition "all 0.3s ease-in-out"
-                       :opacity (if @*hovered? "1" "0")
-                       :display "inline-block"}}
+                        :overflow "hidden"
+                        :margin-left (if @*hovered? "8px" "0")
+                        :transition "all 0.3s ease-in-out"
+                        :opacity (if @*hovered? "1" "0")
+                        :display "inline-block"}}
          [bp-button
           {:icon "cog"
            :class "dont-focus-block"
            :minimal true
            :small true
-           :onClick (fn [e] 
+           :onClick (fn [e]
                       (.stopPropagation e)
                       (on-settings-click))}]]]])))
-                      
+
+(defn extension-running? []
+  (try
+    (boolean (.-running js/window.todoProgressBarExtensionData))
+    (catch :default _e
+      false)))
+
 (defn main [{:keys [block-uid]} & args]
-  (r/with-let [is-running? #(try
-                              (.-running js/window.todoProgressBarExtensionData)
-                              (catch :default _e
-                                false))
-               *running? (r/atom (or (is-running?) nil))
-               *settings-open? (r/atom false)
-               check-interval (js/setInterval #(reset! *running? (is-running?)) 5000)]
-    (case @*running?
-      nil [:div [:strong "Loading progress bar extension..."]]
-      false [:div [:strong {:style {:color "red"}}
-                   "Extension not installed. Please install Todo Progress Bar from Roam Depot."]]
+  (r/with-let [*settings-open? (r/atom false)
+               *ext-ready? (r/atom (extension-running?))
+               check-interval (when-not (extension-running?)
+                                (js/setInterval
+                                 (fn []
+                                   (when (extension-running?)
+                                     (reset! *ext-ready? true)))
+                                 500))
+               _ (js/setTimeout
+                  (fn []
+                    (when check-interval
+                      (js/clearInterval check-interval)))
+                  10000)]
+    (if-not @*ext-ready?
+      [:div [:strong {:style {:color "red"}}
+             "Extension not installed. Please install Todo Progress Bar from Roam Depot."]]
       (let [style (or (first args) "horizontal")
             status-text (or (second args) "Done")
             show-percent (or (nth args 2 nil) "false")
             exclude-blockrefs (or (nth args 3 nil) "false")
-            exclude-blockrefs? (or (= exclude-blockrefs "true") (= exclude-blockrefs true))
-            todo-refs (recurse-search block-uid exclude-blockrefs?)
-            tasks {:todo (count-occurrences "TODO" todo-refs)
-                   :done (count-occurrences "DONE" todo-refs)}
+            tasks (progress-counts block-uid (truthy? exclude-blockrefs))
             total (+ (:todo tasks) (:done tasks))]
-
         [:span.dont-focus-block {:on-click (fn [e] (.stopPropagation e))}
          [bp-popover
           {:isOpen @*settings-open?
@@ -296,8 +286,8 @@
                                    exclude-blockrefs
                                    #(reset! *settings-open? false)])}
           (if (= style "radial")
-            [circle-progress-bar block-uid (:done tasks) total status-text show-percent #(reset! *settings-open? true)]
-            [horizontal-progress-bar block-uid (:done tasks) total status-text show-percent #(reset! *settings-open? true)])]]))
-
+            [circle-progress-bar (:done tasks) total status-text show-percent #(reset! *settings-open? true)]
+            [horizontal-progress-bar (:done tasks) total status-text show-percent #(reset! *settings-open? true)])]]))
     (finally
-      (js/clearInterval check-interval))))
+      (when check-interval
+        (js/clearInterval check-interval))))))

--- a/src/entry-helpers.js
+++ b/src/entry-helpers.js
@@ -72,7 +72,7 @@ async function createBlockIfMissing({ parentUID, uid, order, string, open, headi
 
 async function updateBlockStringIfChanged(uid, nextString) {
   const current = getBlock(uid, "[:block/uid :block/string]");
-  if (!current || current.string === nextString) return false;
+  if (!current || current[":block/string"] === nextString) return false;
 
   await roamAlphaAPI.updateBlock({
     block: {
@@ -209,4 +209,3 @@ export async function toggleStrikethroughCSS(state) {
     removeBlock(STRIKETHROUGH_PARENT_UID);
   }
 }
-

--- a/src/entry-helpers.js
+++ b/src/entry-helpers.js
@@ -1,244 +1,212 @@
 import componentCSSFile from "./component.css";
-import clsjFile from "./component.cljs";
+import cljsFile from "./component.cljs";
 import strikethroughCSSFile from "./strikethrough.css";
 
-function removeCodeBlock(uid){
-    roamAlphaAPI.deleteBlock({"block":{"uid": uid}})
+const TEMPLATE_BLOCK_UID = "roam-render-todo-progress-template";
+const TEMPLATE_RENDER_UID = "roam-render-todo-progress-template-render";
+const CODE_HEADER_UID = "roam-render-todo-progress-code-parent";
+const STRIKETHROUGH_PARENT_UID = "strikethrough-css-parent";
+const STRIKETHROUGH_BLOCK_UID = "strikethrough-css";
+
+function toCodeBlock(language, content) {
+  return `\`\`\`${language}\n${content}\n\`\`\``;
+}
+
+function getBlock(uid, pullPattern = "[:block/uid :block/string]") {
+  return roamAlphaAPI.data.pull(pullPattern, [":block/uid", uid]);
+}
+
+function blockExists(uid) {
+  return Boolean(getBlock(uid, "[:block/uid]"));
+}
+
+function removeBlock(uid) {
+  if (!blockExists(uid)) return;
+  roamAlphaAPI.deleteBlock({ block: { uid } });
 }
 
 function uidForToday() {
-    let roamDate = new Date(Date.now());
-    let today = window.roamAlphaAPI.util.dateToPageTitle(roamDate);
-    return today
+  return window.roamAlphaAPI.util.dateToPageTitle(new Date());
 }
 
-function createPage(title){
-    // creates the roam/css page if it does not exist
-    let pageUID = roamAlphaAPI.util.generateUID()
-    roamAlphaAPI.data
-        .page.create(
-            {"page": 
-                {"title": title, 
-                "uid": pageUID}})
-    return pageUID;
+function createPage(title) {
+  const pageUID = roamAlphaAPI.util.generateUID();
+  roamAlphaAPI.data.page.create({
+    page: {
+      title,
+      uid: pageUID,
+    },
+  });
+  return pageUID;
 }
 
-function getPageUidByPageTitle(title){
-    return roamAlphaAPI.q(
-        `[:find (pull ?e [:block/uid]) :where [?e :node/title "${title}"]]`
-        )?.[0]?.[0].uid || null
+function getPageUidByPageTitle(title) {
+  return (
+    roamAlphaAPI.q(
+      `[:find (pull ?e [:block/uid]) :where [?e :node/title "${title}"]]`
+    )?.[0]?.[0]?.uid || null
+  );
 }
 
-async function createRenderBlock(renderPageName, titleblockUID, version, codeBlockUID, componentName) {
-    console.log('Creating blocks with UIDs:', {
-        titleblockUID,
-        codeBlockUID,
-        renderPageName
+function ensurePage(title) {
+  return getPageUidByPageTitle(title) || createPage(title);
+}
+
+async function createBlockIfMissing({ parentUID, uid, order, string, open, heading }) {
+  if (blockExists(uid)) return false;
+
+  const block = { uid, string };
+  if (typeof open === "boolean") block.open = open;
+  if (typeof heading === "number") block.heading = heading;
+
+  await roamAlphaAPI.createBlock({
+    location: {
+      "parent-uid": parentUID,
+      order,
+    },
+    block,
+  });
+
+  return true;
+}
+
+async function updateBlockStringIfChanged(uid, nextString) {
+  const current = getBlock(uid, "[:block/uid :block/string]");
+  if (!current || current.string === nextString) return false;
+
+  await roamAlphaAPI.updateBlock({
+    block: {
+      uid,
+      string: nextString,
+    },
+  });
+
+  return true;
+}
+
+async function ensureCodeBlock(parentUID, codeBlockUID) {
+  const cljsBlockString = toCodeBlock("clojure", cljsFile);
+
+  if (!blockExists(codeBlockUID)) {
+    await createBlockIfMissing({
+      parentUID,
+      uid: codeBlockUID,
+      order: 0,
+      string: cljsBlockString,
+    });
+    return;
+  }
+
+  await updateBlockStringIfChanged(codeBlockUID, cljsBlockString);
+}
+
+async function ensureCSSBlock(parentUID, cssBlockUID, cssText) {
+  const cssBlockString = toCodeBlock("css", cssText);
+
+  if (!blockExists(cssBlockUID)) {
+    await createBlockIfMissing({
+      parentUID,
+      uid: cssBlockUID,
+      order: 0,
+      string: cssBlockString,
+    });
+    return;
+  }
+
+  await updateBlockStringIfChanged(cssBlockUID, cssBlockString);
+}
+
+async function ensureMainRenderBlocks({
+  componentName,
+  version,
+  titleblockUID,
+  codeBlockUID,
+}) {
+  const renderPageUID = ensurePage("roam/render");
+  const titleCreated = await createBlockIfMissing({
+    parentUID: renderPageUID,
+    uid: titleblockUID,
+    order: 0,
+    string: `${componentName} [[${uidForToday()}]]`,
+    open: true,
+    heading: 3,
+  });
+
+  if (titleCreated) {
+    await createBlockIfMissing({
+      parentUID: titleblockUID,
+      uid: TEMPLATE_BLOCK_UID,
+      order: 0,
+      string: `${componentName} ${version} [[roam/templates]]`,
+      open: true,
     });
 
-    const renderPageUID = getPageUidByPageTitle(renderPageName) || await createPage(renderPageName);
-    console.log('Render page UID:', renderPageUID);
-
-    const templateBlockUID = roamAlphaAPI.util.generateUID();
-    const codeBlockHeaderUID = roamAlphaAPI.util.generateUID();
-    const renderBlockUID = roamAlphaAPI.util.generateUID();
-
-    // Create blocks sequentially with await
-    try {
-        await new Promise(resolve => setTimeout(resolve, 500)); // Add delay before first block
-        await window.roamAlphaAPI.createBlock({
-            location: {
-                "parent-uid": renderPageUID,
-                order: 0
-            },
-            block: {
-                string: `${componentName} [[${uidForToday()}]]`,
-                uid: titleblockUID,
-                open: true,
-                heading: 3
-            }
-        });
-
-        // Wait for title block to exist before creating children
-        await window.roamAlphaAPI.createBlock({
-            location: {
-                "parent-uid": titleblockUID,
-                order: 0
-            },
-            block: {
-                string: `${componentName} ${version} [[roam/templates]]`,
-                uid: templateBlockUID,
-                open: true
-            }
-        });
-
-        await window.roamAlphaAPI.createBlock({
-            location: {
-                "parent-uid": templateBlockUID,
-                order: 0
-            },
-            block: {
-                string: `{{[[roam/render]]:((${codeBlockUID}))}}`,
-                uid: renderBlockUID
-            }
-        });
-
-        await window.roamAlphaAPI.createBlock({
-            location: {
-                "parent-uid": titleblockUID,
-                order: 'last'
-            },
-            block: {
-                string: 'code',
-                uid: codeBlockHeaderUID,
-                open: false
-            }
-        });
-
-        const cljs = clsjFile;
-        const blockString = "```clojure\n " + cljs + " ```";
-        
-        await window.roamAlphaAPI.createBlock({
-            location: {
-                "parent-uid": codeBlockHeaderUID,
-                order: 0
-            },
-            block: {
-                uid: codeBlockUID,
-                string: blockString
-            }
-        });
-
-    } catch (error) {
-        console.error('Error creating blocks:', error);
-        throw error;
-    }
-}
-
-
-async function createCSSBlock(parentUID, cssBlockUID, cssFile, parentString) {
-    const pageUID = getPageUidByPageTitle('roam/css') || createPage('roam/css');
-    
-    try {
-        // Create parent block
-        await roamAlphaAPI.createBlock({
-            location: {
-                "parent-uid": pageUID,
-                order: "last"
-            },
-            block: {
-                string: `${parentString} [[${uidForToday()}]]`,
-                uid: parentUID,
-                open: false,
-                heading: 3
-            }
-        });
-
-        // Create CSS codeblock
-        const css = cssFile.toString();
-        const blockString = "```css\n " + css + " ```";
-        
-        await roamAlphaAPI.createBlock({
-            location: {
-                "parent-uid": parentUID,
-                order: 0
-            },
-            block: {
-                uid: cssBlockUID,
-                string: blockString
-            }
-        });
-    } catch (error) {
-        console.error('Error creating CSS blocks:', error);
-        throw error;
-    }
-}
-
-function replaceRenderString(renderString, replacementString){
-    // replaces the {{[[roam/render]]:((5juEDRY_n))}} string across the entire graph
-    // I do this because when the original block is deleted Roam leaves massive codeblocks wherever it was ref'd
-    // also allows me to re-add back if a user uninstalls and then re-installs
-    
-
-    let query = `[:find
-        (pull ?node [:block/string :node/title :block/uid])
-      :where
-        (or [?node :block/string ?node-String]
-      [?node :node/title ?node-String])
-        [(clojure.string/includes? ?node-String "${renderString}")]
-      ]`;
-    
-    let result = window.roamAlphaAPI.q(query).flat();
-    result.forEach(block => {
-        const updatedString = block.string.replace(renderString, replacementString);
-        window.roamAlphaAPI.updateBlock({
-          block: {
-            uid: block.uid,
-            string: updatedString
-          }
-        });
+    await createBlockIfMissing({
+      parentUID: TEMPLATE_BLOCK_UID,
+      uid: TEMPLATE_RENDER_UID,
+      order: 0,
+      string: `{{[[roam/render]]:((${codeBlockUID}))}}`,
     });
+  }
+
+  // Always ensure the code header exists (covers fresh install and repair).
+  await createBlockIfMissing({
+    parentUID: titleblockUID,
+    uid: CODE_HEADER_UID,
+    order: "last",
+    string: "code",
+    open: false,
+  });
+
+  await ensureCodeBlock(CODE_HEADER_UID, codeBlockUID);
+}
+
+async function ensureMainCSSBlocks({ componentName, cssBlockParentUID, cssBlockUID }) {
+  const cssPageUID = ensurePage("roam/css");
+
+  await createBlockIfMissing({
+    parentUID: cssPageUID,
+    uid: cssBlockParentUID,
+    order: "last",
+    string: `${componentName} STYLE [[${uidForToday()}]]`,
+    open: false,
+    heading: 3,
+  });
+
+  await ensureCSSBlock(cssBlockParentUID, cssBlockUID, componentCSSFile);
+}
+
+export async function ensureTodoProgressComponent({
+  componentName,
+  version,
+  titleblockUID,
+  codeBlockUID,
+  cssBlockParentUID,
+  cssBlockUID,
+}) {
+  await ensureMainRenderBlocks({ componentName, version, titleblockUID, codeBlockUID });
+  await ensureMainCSSBlocks({ componentName, cssBlockParentUID, cssBlockUID });
 }
 
 export async function toggleStrikethroughCSS(state) {
-    const codeBlockParentUID = 'strikethrough-css-parent';
-    const codeBlockUID = 'strikethrough-css';
-    if (state === true) {
-        await createCSSBlock(codeBlockParentUID, codeBlockUID, strikethroughCSSFile, 'DONE Task Strikethrough STYLE');
-    } else if (state === false) {
-        removeCodeBlock(codeBlockParentUID);
-    }
+  if (state === true) {
+    const cssPageUID = ensurePage("roam/css");
+
+    await createBlockIfMissing({
+      parentUID: cssPageUID,
+      uid: STRIKETHROUGH_PARENT_UID,
+      order: "last",
+      string: `DONE Task Strikethrough STYLE [[${uidForToday()}]]`,
+      open: false,
+      heading: 3,
+    });
+
+    await ensureCSSBlock(STRIKETHROUGH_PARENT_UID, STRIKETHROUGH_BLOCK_UID, strikethroughCSSFile);
+    return;
+  }
+
+  if (state === false) {
+    removeBlock(STRIKETHROUGH_PARENT_UID);
+  }
 }
 
-export async function updateCodeBlock(codeBlockUID) {
-    try {
-        const cljs = clsjFile;
-        const blockString = "```clojure\n " + cljs + " ```";
-        
-        // Update the existing block with new content
-        await roamAlphaAPI.updateBlock({
-            block: {
-                uid: codeBlockUID,
-                string: blockString
-            }
-        });
-        console.log("Successfully updated code block content");
-        return true;
-    } catch (error) {
-        console.error("Error updating code block:", error);
-        return false;
-    }
-}
-
-export async function updateCSSBlock(cssBlockUID) {
-    try {
-        const css = componentCSSFile.toString();
-        const blockString = "```css\n " + css + " ```";
-        
-        // Update the existing block with new content
-        await roamAlphaAPI.updateBlock({
-            block: {
-                uid: cssBlockUID,
-                string: blockString
-            }
-        });
-        console.log("Successfully updated CSS block content");
-        return true;
-    } catch (error) {
-        console.error("Error updating CSS block:", error);
-        return false;
-    }
-}
-
-export async function toggleRenderComponent(state, titleblockUID, cssBlockParentUID, version, renderString, replacementString, cssBlockUID, codeBlockUID, componentName) {
-    const renderPageName = 'roam/render';
-    if (state === true) {
-        await createRenderBlock(renderPageName, titleblockUID, version, codeBlockUID, componentName);
-        await createCSSBlock(cssBlockParentUID, cssBlockUID, componentCSSFile, `${componentName} STYLE`);
-    } else if (state === false) {
-        // TODO: since we're not doing anything on state=false maybe call this fn onLoadHelper?
-        // replaceRenderString(renderString, replacementString);
-        // removeCodeBlock(titleblockUID);
-        // removeCodeBlock(cssBlockParentUID);
-    }
-}

--- a/src/index.js
+++ b/src/index.js
@@ -1,83 +1,52 @@
-import { toggleRenderComponent, toggleStrikethroughCSS, updateCodeBlock, updateCSSBlock } from "./entry-helpers";
-//setting this up to be as generic as possible
-//should mostly need to edit the top variables when creating a new extension/version
-const componentName = 'TODO Progress Bar';
-const version = 'v17';
+import { ensureTodoProgressComponent, toggleStrikethroughCSS } from "./entry-helpers";
 
-const componentLowerName = componentName.replaceAll(" ", "-").toLowerCase();
-const codeBlockUID = 'roam-render-todo-progress-cljs';
-const cssBlockUID = 'roam-render-todo-progress-css';
-const renderString = `{{[[roam/render]]:((${codeBlockUID}))}}`;
-const replacementString = '{{todo-progress-bar}}';
-const titleblockUID = 'roam-render-todo-progress';
-const cssBlockParentUID = 'todo-progress-css-parent';
+const componentName = "TODO Progress Bar";
+const version = "v18";
 
-async function onload({extensionAPI}) {
-  const panelConfig = {
-      tabTitle: componentName,
-      settings: [{
-          id: "strikethrough",
-          name: "Strikethrough DONE tasks",
-          description: "Adds CSS to strike through DONE tasks",
-          action: {
-              type: "switch",
-              onChange: async (evt) => {
-                await toggleStrikethroughCSS(evt.target.checked);
-                console.log("toggle strikethrough CSS!", evt.target.checked);
-            }
-          }
-      }]
-  };
+const codeBlockUID = "roam-render-todo-progress-cljs";
+const cssBlockUID = "roam-render-todo-progress-css";
+const titleblockUID = "roam-render-todo-progress";
+const cssBlockParentUID = "todo-progress-css-parent";
 
-  extensionAPI.settings.panel.create(panelConfig);
+async function onload({ extensionAPI }) {
+  extensionAPI.settings.panel.create({
+    tabTitle: componentName,
+    settings: [
+      {
+        id: "strikethrough",
+        name: "Strikethrough DONE tasks",
+        description: "Adds CSS to strike through DONE tasks",
+        action: {
+          type: "switch",
+          onChange: async (evt) => {
+            await toggleStrikethroughCSS(evt.target.checked);
+          },
+        },
+      },
+    ],
+  });
 
-  window.todoProgressBarExtensionData = {running: true};
-  console.log(`Loading ${componentName} plugin version ${version}`);
-  
+  window.todoProgressBarExtensionData = { running: true };
+
   try {
-      // Check if the component block exists
-      const existingComponent = roamAlphaAPI.data.pull("[*]", [":block/uid", titleblockUID]);
-      console.log(`Component block check (${titleblockUID}):`, existingComponent ? "Found" : "Not found");
-      
-      // Check if the code block exists 
-      const existingCodeBlock = roamAlphaAPI.data.pull("[*]", [":block/uid", codeBlockUID]);
-      console.log(`Code block check (${codeBlockUID}):`, existingCodeBlock ? "Found" : "Not found");
-      
-      if (!existingComponent) {
-          console.log("Component blocks not found, creating new blocks...");
-          await toggleRenderComponent(true, titleblockUID, cssBlockParentUID, version, renderString, replacementString, cssBlockUID, codeBlockUID, componentName);
-      } else {
-          console.log("Component blocks exist, checking if code block needs updating...");
-          
-          // Now explicitly update the code block content even if it exists
-          if (existingCodeBlock) {
-              console.log("Updating existing code block with latest version...");
-              await updateCodeBlock(codeBlockUID);
-          } else {
-              console.log("Code block not found despite component existing - may need repair");
-              // TODO could implement repair logic here if needed
-          }
-          
-          // Also update the CSS block
-          const existingCSSBlock = roamAlphaAPI.data.pull("[*]", [":block/uid", cssBlockUID]);
-          if (existingCSSBlock) {
-              console.log("Updating CSS block...");
-              await updateCSSBlock(cssBlockUID);
-          }
-      }
-      console.log(`Completed loading ${componentName} plugin`);
+    await ensureTodoProgressComponent({
+      componentName,
+      version,
+      titleblockUID,
+      codeBlockUID,
+      cssBlockParentUID,
+      cssBlockUID,
+    });
   } catch (error) {
-      console.error('Error loading plugin:', error);
+    console.error("Error loading plugin:", error);
   }
 }
 
 function onunload() {
   window.todoProgressBarExtensionData = null;
-  toggleRenderComponent(false, titleblockUID, cssBlockParentUID, version, renderString, replacementString, cssBlockUID, codeBlockUID, componentName)
-  console.log(`unload ${componentName} plugin`)
 }
 
 export default {
-onload,
-onunload
+  onload,
+  onunload,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,31 +1,27 @@
 module.exports = {
-    externals: {
-        react: "React",
-        "chrono-node": "ChronoNode"
+  externals: {
+    react: "React",
+    "chrono-node": "ChronoNode",
+  },
+  externalsType: "window",
+  entry: "./src/index.js",
+  output: {
+    filename: "extension.js",
+    path: __dirname,
+    library: {
+      type: "module",
     },
-    externalsType: "window",
-    entry: './src/index.js',
-    output: {
-        filename: 'extension.js',
-        path: __dirname,
-        library: {
-            type: "module",
-        }
-    },
-    experiments: {
-        outputModule: true,
-    },
-    mode: "production",
-    module: {
-        rules: [
-            {
-            test: /\.cljs$/,
-            use: 'text-loader',
-            },
-          {
-            test: /\.css$/,
-            use: 'css-loader',
-          },
-        ],
+  },
+  experiments: {
+    outputModule: true,
+  },
+  mode: "production",
+  module: {
+    rules: [
+      {
+        test: /\.(cljs|css)$/,
+        use: "text-loader",
       },
+    ],
+  },
 };


### PR DESCRIPTION
## Summary

Follow-up to #5. Ran a code review on the blockref-toggle branch and found several issues worth fixing before the next release:

- **Version mismatch:** ClojureScript namespace was `progress-bar-v17` while `index.js` said `v18`. Aligned everything to v18 including `package.json`.
- **Idempotent install:** Rewrote the block creation flow in `entry-helpers.js` to use an `ensure*` pattern. Repeated `onload` calls are now safe and won't duplicate blocks. Also consolidated a redundant `CODE_HEADER_UID` creation path.
- **Race condition:** The render component showed a permanent error if it mounted before `onload` finished. Added brief polling (500ms, 10s cap) with cleanup.
- **Brittle regex:** Block-ref UID pattern was hardcoded to exactly 9 chars. Now accepts any length.
- **Build simplification:** Replaced `css-loader` with `text-loader` for CSS imports, dropping the PostCSS dependency.
- **Dead code:** Removed unused legacy exports and the old `datascript.core` import.